### PR TITLE
AU-579: Fix file upload prepended data

### DIFF
--- a/src/AtvService.php
+++ b/src/AtvService.php
@@ -862,25 +862,21 @@ class AtvService {
     // Get file data.
     $body = Utils::tryFopen($filePath, 'r');
 
-    // Form data.
-    $data = [
-      'name' => $filename,
-      'filename' => $filename,
-      'contents' => $body,
-    ];
-
     try {
       $retval = $this->doRequest(
         'POST',
         $this->buildUrl('documents/' . $documentId . '/attachments'),
         [
           'headers' => $headers,
-          'multipart' => [$data],
+          'body' => $body,
         ]
       );
 
     }
     catch (AtvAuthFailedException | TokenExpiredException $e) {
+      // Delete from local filesystem.
+      $file->delete();
+
       $this->logger->error(
         'File upload failed with error: @error',
         ['@error' => $e->getMessage()]


### PR DESCRIPTION
Attachment upload function currently uploads the multipart-formatted data as the file data. This was fixed so that attachment uploads are sent in full in POST request body.

Changes:
- Changed the attachment upload function to use the POST request body as the source of file data, not multipart form data.
- Remove Drupal local filesystem file if upload fails.