### PR TITLE
fix: AU-1821: Add slash to documents endpoint

### DIFF
--- a/src/AtvService.php
+++ b/src/AtvService.php
@@ -400,7 +400,7 @@ class AtvService {
 
     $responseData = $this->doRequest(
       'GET',
-      $this->buildUrl('documents', $searchParams),
+      $this->buildUrl('documents/', $searchParams),
       [
         'headers' => $this->headers,
       ]


### PR DESCRIPTION
Missing slash in documents endpoint leads to redirect in ATV that possibly slows our queries down