### PR TITLE
fix: AU-1928 Fix profile uploads failing

### DIFF
--- a/src/AtvService.php
+++ b/src/AtvService.php
@@ -869,6 +869,18 @@ class AtvService {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function uploadAttachment(string $documentId, string $filename, File $file): mixed {
+
+    try {
+      $this->setAuthHeaders();
+    }
+    catch (AtvAuthFailedException | TokenExpiredException $e) {
+      $this->logger->error(
+        'File upload failed with error: @error',
+        ['@error' => $e->getMessage()]
+          );
+      return FALSE;
+    }
+
     $headers = $this->headers;
     $headers['Content-Disposition'] = 'attachment; filename="' . $filename . '"';
     $headers['Content-Type'] = 'application/octet-stream';


### PR DESCRIPTION
Profile uploads didn't get correct headers.

* Reintroduce setAuthHeaders to tuploadAttachment method

**How to test**

In grants project:

* [ ] Try to upload attachments in profile forms.
* [ ] Try to upload attachments in grants application.

Both should succeed.