### PR TITLE
AU-2214: Set X-Api-Key headers in doRequest if using flag

### DIFF
--- a/src/AtvService.php
+++ b/src/AtvService.php
@@ -1048,7 +1048,7 @@ class AtvService {
       if ($apiKeyAuth) {
         // Set headers from configs.
         $this->setAuthHeaders(TRUE);
-
+        $options['headers']['X-Api-Key'] = $this->headers['X-Api-Key'];
       }
       // If we don't have Authorization headers, we need to get them.
       elseif (empty($options['headers'])) {


### PR DESCRIPTION
# [AU-2214](https://helsinkisolutionoffice.atlassian.net/browse/AU-2214)
<!-- What problem does this solve? -->

Fix missing headers when using api key auth.


[AU-2214]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ