### PR TITLE
AU-2123: Update version constrains for D10, run PHPCS fixes.

### DIFF
--- a/modules/helfi_atv_audit_logging/helfi_atv_audit_logging.info.yml
+++ b/modules/helfi_atv_audit_logging/helfi_atv_audit_logging.info.yml
@@ -2,8 +2,7 @@ name: helfi_atv_audit_logging
 type: module
 description: Adds audit log features to ATV module
 package: Hel.fi
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - helfi_atv
   - helfi_audit_log

--- a/modules/helfi_atv_audit_logging/src/EventSubscriber/AtvServiceEventSubscriber.php
+++ b/modules/helfi_atv_audit_logging/src/EventSubscriber/AtvServiceEventSubscriber.php
@@ -51,7 +51,7 @@ class AtvServiceEventSubscriber implements EventSubscriberInterface {
   /**
    * Audit log the operation.
    *
-   * @param \Drupal\helfi_atv\Event\AtvServiceEOperationEvent $event
+   * @param \Drupal\helfi_atv\Event\AtvServiceOperationEvent $event
    *   An operation event.
    */
   public function onOperation(AtvServiceOperationEvent $event) {


### PR DESCRIPTION
# [AU-2123](https://helsinkisolutionoffice.atlassian.net/browse/AU-2123)

## What was done

## How to install
* Follow instructions in this PR: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1241
* Install test branches for all updated modules:
  *  `composer require drupal/helfi_atv:dev-AU-2123-d10-updates drupal/helfi_helsinki_profiili:dev-AU-2123-d10-updates drupal/helfi_yjdh:dev-AU-2123-d10-updates`

## How to test
* [ ] You should no longer get a warning about these incompatible modules when you run `drush updb` for example on the D10 branch
* [ ] Check that code follows our standards
* [ ] Run `make test-pw` just in case

## Automatic- / Regression tests
* [X] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
* https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1241
* https://github.com/City-of-Helsinki/drupal-module-helfi-helsinki-profiili/pull/25
* https://github.com/City-of-Helsinki/drupal-module-helfi-yjdh/pull/1

[AU-2123]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ