### PR TITLE
feat: AU-1934: Modify json output

### DIFF
--- a/tests/src/Unit/AtvServiceUnitTest.php
+++ b/tests/src/Unit/AtvServiceUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\helfi_atv\Unit;
 
+use Drupal\Component\Serialization\Json;
 use Drupal\helfi_atv\AtvService;
 use Drupal\Tests\UnitTestCase;
 
@@ -37,6 +38,58 @@ class AtvServiceUnitTest extends UnitTestCase {
     $userRoles4 = [];
     $result4 = AtvService::hasAllowedRole($allowedRoles4, $userRoles4);
     $this->assertEquals(FALSE, $result4);
+
+  }
+
+  /**
+   * Test arrayWalkRecursive.
+   */
+  public function testArrayWalkRecursive() {
+    $arrayData1a = [
+      'test1' => [],
+      'test2' => [],
+      'test3' => [],
+    ];
+    $json1a = Json::encode($arrayData1a);
+    $this->assertEquals('{"test1":[],"test2":[],"test3":[]}', $json1a);
+    $arrayData1b = [
+      'test1' => [],
+      'test2' => [],
+      'test3' => [],
+    ];
+    $json1b = Json::encode(AtvService::arrayWalkRecursive($arrayData1b));
+    $this->assertEquals('{"test1":{},"test2":{},"test3":{}}', $json1b);
+
+    $arrayData2 = [
+      'test1' => ['value' => '2'],
+      'test2' => ['value' => 'string'],
+      'test3' => ['value' => ''],
+    ];
+    $json2 = Json::encode(AtvService::arrayWalkRecursive($arrayData2));
+    $this->assertEquals('{"test1":{"value":"2"},"test2":{"value":"string"},"test3":{"value":""}}', $json2);
+    $arrayData3 = [
+      [
+        'test1' => [],
+        'test2' => [],
+        'test3' => [],
+      ],
+      [
+        'test4' => [],
+        'test5' => [],
+        'test6' => [],
+      ],
+    ];
+    $json3 = Json::encode(AtvService::arrayWalkRecursive($arrayData3));
+    $this->assertEquals('[{"test1":{},"test2":{},"test3":{}},{"test4":{},"test5":{},"test6":{}}]', $json3);
+    // Test Xss filtering.
+    $arrayData4 = [
+      'test1' => ['value' => '<b>Bold<b>'],
+      'test2' => ['value' => '<script>evil</script>'],
+      'test3' => ['value' => ''],
+      'test4' => [],
+    ];
+    $json4 = Json::encode(AtvService::arrayWalkRecursive($arrayData4));
+    $this->assertEquals('{"test1":{"value":"Bold"},"test2":{"value":"evil"},"test3":{"value":""},"test4":{}}', $json4);
 
   }
 


### PR DESCRIPTION
# [AU-1934](https://helsinkisolutionoffice.atlassian.net/browse/AU-1934)
<!-- What problem does this solve? -->

Integraatio/Avustus2 ei hyväksy tyhjiä arrayta `[]` jsonissa jos sen tilalla tulisi olla `{}`

## What was done
<!-- Describe what was done -->

* Käy data läpi ja tee tyhjistä PHP arrayista stdObjekteja
* Lisää testit

## How to install

Käytä linkitettyä pullaria testaamiseen

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Testit toimivat
* [ ] Data liikkuu eteenpäin. Nykytilanteessa tyhjiä arraytä ei tule joten testaaminen saattaa vaatia kikkoja

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Toiminnallisuuden testaus: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1398


[AU-1934]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ