### PR TITLE
AU-2518: Change getUserId signature as this may be null in some cases

### DIFF
--- a/src/AtvDocument.php
+++ b/src/AtvDocument.php
@@ -523,11 +523,11 @@ final class AtvDocument implements \JsonSerializable {
   /**
    * Get user id.
    *
-   * @return string
+   * @return string|null
    *   Document user id.
    */
-  public function getUserId(): string {
-    return $this->userId;
+  public function getUserId(): string|null {
+    return $this->userId ?? NULL;
   }
 
   /**


### PR DESCRIPTION
# [AU-2518](https://helsinkisolutionoffice.atlassian.net/browse/AU-2518)
<!-- What problem does this solve? -->

## What was done

* Allow getUserId() to return NULL values, as in some cases (like GDPR deletion) it might actually be NULL.

## How to install

* Make sure your instance is up and running on correct branch.
  * `composer require "drupal/helfi_atv:dev-feature/AU-2518-userid as 0.9.29"`



[AU-2518]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ