### PR TITLE
Revert "feat: AU-1934: Modify json output"

### DIFF
--- a/src/AtvService.php
+++ b/src/AtvService.php
@@ -631,38 +631,6 @@ class AtvService {
   }
 
   /**
-   * Own implemenation of native array_walk_recursive.
-   */
-  public static function arrayWalkRecursive(&$items) {
-
-    foreach ($items as $key => $value) {
-      if (is_array($items[$key]) && empty($value)) {
-        $items[$key] = new \stdClass();
-      }
-      elseif (is_array($items[$key])) {
-        // Go level down if the current $value happens to be an array.
-        $items[$key] = self::arrayWalkRecursive($value);
-      }
-      else {
-        // Apply callback function to modify leaf values.
-        $items[$key] = self::xssFilter($value);
-      }
-    }
-    // Return an updated array.
-    return $items;
-  }
-
-  /**
-   * Helper function for xss filtering.
-   */
-  protected static function xssFilter($item) {
-    if (is_string($item)) {
-      $item = Xss::filter($item);
-    }
-    return $item;
-  }
-
-  /**
    * Parse array data to form data.
    *
    * @param array $document
@@ -675,7 +643,14 @@ class AtvService {
     $retval = [];
     foreach ($document as $key => $value) {
       if (is_array($value)) {
-        self::arrayWalkRecursive($value);
+        array_walk_recursive(
+          $value,
+          function (&$item) {
+            if (is_string($item)) {
+              $item = Xss::filter($item);
+            }
+          }
+        );
         $contents = Json::encode($value);
       }
       else {

--- a/tests/src/Unit/AtvServiceUnitTest.php
+++ b/tests/src/Unit/AtvServiceUnitTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\helfi_atv\Unit;
 
-use Drupal\Component\Serialization\Json;
 use Drupal\helfi_atv\AtvService;
 use Drupal\Tests\UnitTestCase;
 
@@ -38,58 +37,6 @@ class AtvServiceUnitTest extends UnitTestCase {
     $userRoles4 = [];
     $result4 = AtvService::hasAllowedRole($allowedRoles4, $userRoles4);
     $this->assertEquals(FALSE, $result4);
-
-  }
-
-  /**
-   * Test arrayWalkRecursive.
-   */
-  public function testArrayWalkRecursive() {
-    $arrayData1a = [
-      'test1' => [],
-      'test2' => [],
-      'test3' => [],
-    ];
-    $json1a = Json::encode($arrayData1a);
-    $this->assertEquals('{"test1":[],"test2":[],"test3":[]}', $json1a);
-    $arrayData1b = [
-      'test1' => [],
-      'test2' => [],
-      'test3' => [],
-    ];
-    $json1b = Json::encode(AtvService::arrayWalkRecursive($arrayData1b));
-    $this->assertEquals('{"test1":{},"test2":{},"test3":{}}', $json1b);
-
-    $arrayData2 = [
-      'test1' => ['value' => '2'],
-      'test2' => ['value' => 'string'],
-      'test3' => ['value' => ''],
-    ];
-    $json2 = Json::encode(AtvService::arrayWalkRecursive($arrayData2));
-    $this->assertEquals('{"test1":{"value":"2"},"test2":{"value":"string"},"test3":{"value":""}}', $json2);
-    $arrayData3 = [
-      [
-        'test1' => [],
-        'test2' => [],
-        'test3' => [],
-      ],
-      [
-        'test4' => [],
-        'test5' => [],
-        'test6' => [],
-      ],
-    ];
-    $json3 = Json::encode(AtvService::arrayWalkRecursive($arrayData3));
-    $this->assertEquals('[{"test1":{},"test2":{},"test3":{}},{"test4":{},"test5":{},"test6":{}}]', $json3);
-    // Test Xss filtering.
-    $arrayData4 = [
-      'test1' => ['value' => '<b>Bold<b>'],
-      'test2' => ['value' => '<script>evil</script>'],
-      'test3' => ['value' => ''],
-      'test4' => [],
-    ];
-    $json4 = Json::encode(AtvService::arrayWalkRecursive($arrayData4));
-    $this->assertEquals('{"test1":{"value":"Bold"},"test2":{"value":"evil"},"test3":{"value":""},"test4":{}}', $json4);
 
   }
 


### PR DESCRIPTION
Reverts City-of-Helsinki/drupal-module-helfi-atv#34

Datamallissa on siis joitakin arrayta jotka voivat olla tyhjiä kun data lähtee Avustus 2:seen. Tämä toteutus on siis liian yksinkertainen. Tämä korjaus oli tavoitteli future-proofingia mutta tästä tuli enemmän present-issues joten lienee järkevintä revertata tämä.

Tutkin josko voisi käyttää apuna tietoliikenneschemaa ja sen perusteella katsoa onko kyseessä [] vai {}. Mutta tällöin ATV-moduulin tulisi tietää minkälainen dokumentti on kyseessä ja tämä lisäisi logiikkaa varsin paljon.

ATVSchemassa schema-dataa jo käytetään. Mutta tyhjää arrayta on vaikea merkitä mitenkään helposti tietyn tyyppiseksi. 

Ainoa selkeä ja luotettavasti tapa olisi muuttaa kaikki koodi käyttämään objekteja mutta tästä tulisi valtava uudelleenkirjoitusurakka.