### PR TITLE
fix: UHF-10202: Update test signature to support new class

### DIFF
--- a/tests/modules/helfi_atv_test/src/MockFileRepository.php
+++ b/tests/modules/helfi_atv_test/src/MockFileRepository.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\helfi_atv_test;
 
-use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\File\FileExists;
 use Drupal\file\Entity\File;
 use Drupal\file\FileInterface;
 use Drupal\file\FileRepository;
@@ -15,7 +15,7 @@ class MockFileRepository extends FileRepository {
   /**
    * Mock version.
    */
-  public function writeData(string $data, string $destination, int $replace = FileSystemInterface::EXISTS_RENAME): FileInterface {
+  public function writeData(string $data, string $destination, FileExists|int $fileExists = FileExists::Rename): FileInterface {
     $fileName = __DIR__ . '/uploadAttachment.txt';
     $file = File::create(['uri' => $fileName]);
     return $file;


### PR DESCRIPTION
# [UHF-10202](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10202)
<!-- What problem does this solve? -->

The PR in main repo fails because of this incorrect test definition. 

Just small fix to allow tests to run.

## What was done
<!-- Describe what was done -->

* Fixed writeData mock method with proper signature.

## Other PRs
<!-- For example an related PR in another repository -->

* [Link to other PR](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1465)


[UHF-10202]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ